### PR TITLE
Setting(feat): 글자 크기 조정

### DIFF
--- a/YaGi/YaGi.xcodeproj/project.pbxproj
+++ b/YaGi/YaGi.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		14ACAAFB2A6271C600CF4043 /* CSSymbolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14ACAAFA2A6271C600CF4043 /* CSSymbolButton.swift */; };
 		14BACB56297F8D9F0021BE5E /* BookmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BACB55297F8D9F0021BE5E /* BookmarkViewController.swift */; };
 		14BACB58297F912C0021BE5E /* BookmarkTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BACB57297F912C0021BE5E /* BookmarkTableViewCell.swift */; };
+		14CBA04B2A64F40D0016D8B6 /* SettingLayoutModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CBA04A2A64F40D0016D8B6 /* SettingLayoutModel.swift */; };
 		14D26F1729A32E9700798F99 /* BookshelfViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D26F1629A32E9700798F99 /* BookshelfViewController.swift */; };
 		14E5D9A428F155D200E349B4 /* WritingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E5D9A328F155D200E349B4 /* WritingViewController.swift */; };
 		14E5D9A628F1583500E349B4 /* ContentDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E5D9A528F1583500E349B4 /* ContentDetailViewController.swift */; };
@@ -104,6 +105,7 @@
 		14ACAAFA2A6271C600CF4043 /* CSSymbolButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSSymbolButton.swift; sourceTree = "<group>"; };
 		14BACB55297F8D9F0021BE5E /* BookmarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewController.swift; sourceTree = "<group>"; };
 		14BACB57297F912C0021BE5E /* BookmarkTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkTableViewCell.swift; sourceTree = "<group>"; };
+		14CBA04A2A64F40D0016D8B6 /* SettingLayoutModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingLayoutModel.swift; sourceTree = "<group>"; };
 		14D26F1629A32E9700798F99 /* BookshelfViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookshelfViewController.swift; sourceTree = "<group>"; };
 		14E5D9A328F155D200E349B4 /* WritingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingViewController.swift; sourceTree = "<group>"; };
 		14E5D9A528F1583500E349B4 /* ContentDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDetailViewController.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				140BE4E728EEA5FF00052664 /* ContentModel.swift */,
 				148F5E8D296A800400A69B9C /* BookModel.swift */,
 				14F5EE0529AB0B1E00DFBEA9 /* ContentsCollectionItemModel.swift */,
+				14CBA04A2A64F40D0016D8B6 /* SettingLayoutModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -467,6 +470,7 @@
 				140C3EE129C96CDC00B4EF86 /* Chapter+CoreDataProperties.swift in Sources */,
 				14ACAAFB2A6271C600CF4043 /* CSSymbolButton.swift in Sources */,
 				140C3EEE29C98B8400B4EF86 /* UserDafaultStandardWrapper.swift in Sources */,
+				14CBA04B2A64F40D0016D8B6 /* SettingLayoutModel.swift in Sources */,
 				14BACB58297F912C0021BE5E /* BookmarkTableViewCell.swift in Sources */,
 				148ED33E2A64027E00A4F1CD /* CSStepper.swift in Sources */,
 			);

--- a/YaGi/YaGi/Custom/CSDetailView.swift
+++ b/YaGi/YaGi/Custom/CSDetailView.swift
@@ -44,15 +44,17 @@ private extension CSDetailView {
     func configure() {
         scrollView.backgroundColor = .yagiWhite
         
+        let layout = UserDefaultsManager.layout
+        let textSize = CGFloat(layout?.textSize ?? 20)
         contentTitle.attributedText = configureString()
-        contentTitle.font = .maruburi(ofSize: 20, weight: .bold)
+        contentTitle.font = .maruburi(ofSize: textSize, weight: .bold)
         contentTitle.textColor = .yagiGrayDeep
         contentTitle.minimumScaleFactor = 0.9
         contentTitle.adjustsFontSizeToFitWidth = true
         contentTitle.numberOfLines = 0
         
         contentLabel.attributedText = configureString()
-        contentLabel.font = .maruburi(ofSize: 20, weight: .regular)
+        contentLabel.font = .maruburi(ofSize: textSize, weight: .regular)
         contentLabel.textColor = .yagiGrayDeep
         contentLabel.numberOfLines = 0
         

--- a/YaGi/YaGi/Custom/CSStepper.swift
+++ b/YaGi/YaGi/Custom/CSStepper.swift
@@ -36,8 +36,10 @@ class CSStepper: UIControl {
         fatalError("init(coder:) has not been implemented")
     }
     
-    init() {
+    init(value: Int) {
         super.init(frame: .zero)
+        
+        self.value = value
         configure()
         layout()
     }

--- a/YaGi/YaGi/Data/Model/SettingLayoutModel.swift
+++ b/YaGi/YaGi/Data/Model/SettingLayoutModel.swift
@@ -1,0 +1,16 @@
+//
+//  SettingLayoutModel.swift
+//  YaGi
+//
+//  Created by 임윤휘 on 2023/07/17.
+//
+
+import Foundation
+
+struct SettingLayoutModel: Codable {
+    let textSize: Int
+    
+    init(textSize:Int = 20) {
+        self.textSize = textSize
+    }
+}

--- a/YaGi/YaGi/Data/UserDafaultsManager.swift
+++ b/YaGi/YaGi/Data/UserDafaultsManager.swift
@@ -11,6 +11,9 @@ struct UserDefaultsManager {
     @UserDefaultWrapper(dictionaryKey: "Books", defaultValue: nil)
     static var books: [BookModel]?
     
+    @UserDefaultWrapper(dictionaryKey: "Layout", defaultValue: SettingLayoutModel())
+    static var layout: SettingLayoutModel?
+    
     @UserDefaultStandardWrapper(dictionaryKey: "isImplovedData", defaultValue: false)
     static var isImplovedData: Bool?
 }

--- a/YaGi/YaGi/Scenes/Contents/Writing/WritingViewController.swift
+++ b/YaGi/YaGi/Scenes/Contents/Writing/WritingViewController.swift
@@ -177,12 +177,14 @@ class WritingViewController: UIViewController {
         let attributes: [NSAttributedString.Key : Any] = [NSAttributedString.Key.paragraphStyle : paragraphStyle]
         let attributedText = NSAttributedString(string:text, attributes: attributes)
         
+        let layout = UserDefaultsManager.layout
+        let textSize = CGFloat(layout?.textSize ?? 20)
         textView.attributedText = attributedText
         textView.isEditable = true
         textView.isScrollEnabled = false
         textView.textColor = .placeholderText
         textView.tintColor = .yagiHighlight
-        textView.font = .maruburi(ofSize: 20, weight: .bold)
+        textView.font = .maruburi(ofSize: textSize, weight: .bold)
         textView.inputAccessoryView = keyboardToolBar
         
         textView.delegate = self
@@ -202,13 +204,15 @@ class WritingViewController: UIViewController {
         let attributes: [NSAttributedString.Key : Any] = [NSAttributedString.Key.paragraphStyle : paragraphStyle]
         let attributedText = NSAttributedString(string:text, attributes: attributes)
         
+        let layout = UserDefaultsManager.layout
+        let textSize = CGFloat(layout?.textSize ?? 20)
         textView.attributedText = attributedText
         textView.isEditable = true
         textView.text = text
         textView.isScrollEnabled = false
         textView.textColor = .placeholderText
         textView.tintColor = .yagiHighlight
-        textView.font = .maruburi(ofSize: 20, weight: .regular)
+        textView.font = .maruburi(ofSize: textSize, weight: .regular)
         textView.inputAccessoryView = keyboardToolBar
         
         textView.delegate = self

--- a/YaGi/YaGi/Scenes/Setting/SettingLayout/SettingTextSizeViewController.swift
+++ b/YaGi/YaGi/Scenes/Setting/SettingLayout/SettingTextSizeViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 class SettingTextSizeViewController: UIViewController {
     
     //MARK: - View
-    private var stepper = CSStepper()
+    private var stepper = CSStepper(value: UserDefaultsManager.layout?.textSize ?? 20)
     private var detailView = CSDetailView()
     private var doneButton = UIButton()
     
@@ -57,6 +57,7 @@ private extension SettingTextSizeViewController {
 """
         doneButton.tintColor = .yagiHighlight
         doneButton.setImage(UIImage(systemName: "checkmark"), for: .normal)
+        doneButton.addTarget(self, action: #selector(didTapDoneButton), for: .touchUpInside)
         
         stepper.addTarget(self, action: #selector(changeTextSize), for: .valueChanged)
         

--- a/YaGi/YaGi/Scenes/Setting/SettingLayout/SettingTextSizeViewController.swift
+++ b/YaGi/YaGi/Scenes/Setting/SettingLayout/SettingTextSizeViewController.swift
@@ -33,7 +33,8 @@ class SettingTextSizeViewController: UIViewController {
     }
     
     @objc func didTapDoneButton() {
-        print("Set TextSize")
+        let layout = SettingLayoutModel(textSize: stepper.value)
+        UserDefaultsManager.layout = layout
         self.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
# 👩‍💻구현 내용
글자 크기 조정 화면 기능 구현
- SettingLayoutModel: 레이아웃 설정 데이터 모델
- UserDefaultsManager.layout: 기기 내 저장된 레이아웃 설정 사용 manager
- CSStepper 초기화 구현 - value 설정
- 글자 크기 조정 화면 '완료' 버튼: tap 시 기기 내 저장 및 dismiss

<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/88yhtserof/YaGi/assets/65601189/dbc8f1ed-cf7e-4334-b611-80074e1c9720" width = 350 height = 750> |



 <br>
#73 
